### PR TITLE
Compile benchmark with Dotty, fixes #29.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 env:
   global:
 
-script: sbt test:compile "hot -psource=scalap -w1 -f1" "micro/jmh:run -w1 -f1"
+script: sbt test:compile "hot -psource=scalap -w1 -f1" "micro/jmh:run -w1 -f1" "; project compilation ; +test"
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 env:
   global:
 
-script: sbt test:compile "hot -psource=scalap -w1 -f1" "micro/jmh:run -w1 -f1" "; project compilation ; +test"
+script: sbt test:compile "hot -psource=scalap -w1 -f1" "; project compilation ; +test" "micro/jmh:run -w1 -f1"
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 env:
   global:
 
-script: sbt test:compile "hot -psource=scalap -w1 -f1" "; project compilation ; +test" "micro/jmh:run -w1 -f1"
+script: sbt testAll
 
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,18 @@ def scala211 = "2.11.11"
 def dottyLatest = "0.2.0-RC1"
 scalaVersion in ThisBuild := scala211
 
+commands += Command.command("testAll") { s =>
+  "test:compile" ::
+    "compilation/test" ::
+    "hot -psource=scalap -wi 1 -i 1 -f1" ::
+    "++0.2.0-RC1" ::
+    "compilation/test" ::
+    "hot -psource=vector -wi 1 -i 1 -f1" ::
+    "++2.11.8" ::
+    "micro/jmh:run -w1 -f1" ::
+    s
+}
+
 resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
 
 // Convenient access to builds from PR validation

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,9 @@ name := "compiler-benchmark"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion in ThisBuild := "2.11.8"
+def scala211 = "2.11.11"
+def dottyLatest = "0.2.0-RC1"
+scalaVersion in ThisBuild := scala211
 
 resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
 
@@ -40,6 +42,7 @@ lazy val compilation = addJmh(project).settings(
     if (isDotty.value) "ch.epfl.lamp" %% "dotty-compiler" % scalaVersion.value
     else scalaOrganization.value % "scala-compiler" % scalaVersion.value
   },
+  crossScalaVersions := List(scala211, dottyLatest),
   unmanagedSourceDirectories.in(Compile) +=
     sourceDirectory.in(Compile).value / (if (isDotty.value) "dotc" else "scalac"),
   mainClass in (Jmh, run) := Some("scala.bench.ScalacBenchmarkRunner"),

--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,10 @@ commands += Command.command("testAll") { s =>
   "test:compile" ::
     "compilation/test" ::
     "hot -psource=scalap -wi 1 -i 1 -f1" ::
-    "++0.2.0-RC1" ::
+    s"++$dottyLatest" ::
     "compilation/test" ::
     "hot -psource=vector -wi 1 -i 1 -f1" ::
-    "++2.11.8" ::
+    s"++$scala211" ::
     "micro/jmh:run -w1 -f1" ::
     s
 }

--- a/build.sbt
+++ b/build.sbt
@@ -45,8 +45,7 @@ lazy val compilation = addJmh(project).settings(
   mainClass in (Jmh, run) := Some("scala.bench.ScalacBenchmarkRunner"),
   libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
   testOptions in Test += Tests.Argument(TestFrameworks.JUnit),
-  fork in (Test, test) := true,
-  fork in run := true
+  fork in (Test, test) := true // jmh scoped tasks run with fork := true.
 ).settings(addJavaOptions).dependsOn(infrastructure)
 
 lazy val micro = addJmh(project).settings(

--- a/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
@@ -6,7 +6,7 @@ import dotty.tools.dotc.core.Contexts.ContextBase
 
 trait BenchmarkDriver extends BaseBenchmarkDriver {
   def compileImpl(): Unit = {
-    implicit val ctx = (new ContextBase).initialCtx.fresh
+    implicit val ctx = new ContextBase().initialCtx.fresh
     ctx.setSetting(ctx.settings.usejavacp, true)
     if (depsClasspath != null) {
       ctx.setSetting(ctx.settings.classpath,
@@ -15,8 +15,8 @@ trait BenchmarkDriver extends BaseBenchmarkDriver {
     ctx.setSetting(ctx.settings.d, tempDir.getAbsolutePath)
     ctx.setSetting(ctx.settings.language, List("Scala2"))
     val compiler = new dotty.tools.dotc.Compiler
-    val reporter =
-      dotty.tools.dotc.Bench.doCompile(compiler, compilerArgs.toList)
+    val args = compilerArgs ++ sourceFiles
+    val reporter = dotty.tools.dotc.Bench.doCompile(compiler, args)
     assert(!reporter.hasErrors)
   }
 }

--- a/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
@@ -12,6 +12,7 @@ trait BenchmarkDriver extends BaseBenchmarkDriver {
       ctx.setSetting(ctx.settings.classpath,
                      depsClasspath.mkString(File.pathSeparator))
     }
+    ctx.setSetting(ctx.settings.migration, true)
     ctx.setSetting(ctx.settings.d, tempDir.getAbsolutePath)
     ctx.setSetting(ctx.settings.language, List("Scala2"))
     val compiler = new dotty.tools.dotc.Compiler

--- a/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
@@ -16,8 +16,7 @@ trait BenchmarkDriver extends BaseBenchmarkDriver {
     ctx.setSetting(ctx.settings.d, tempDir.getAbsolutePath)
     ctx.setSetting(ctx.settings.language, List("Scala2"))
     val compiler = new dotty.tools.dotc.Compiler
-    val args = compilerArgs ++ sourceFiles
-    val reporter = dotty.tools.dotc.Bench.doCompile(compiler, args)
+    val reporter = dotty.tools.dotc.Bench.doCompile(compiler, allArgs)
     assert(!reporter.hasErrors)
   }
 }

--- a/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
@@ -1,0 +1,22 @@
+package scala.tools.benchmark
+
+import java.io.File
+import scala.tools.nsc.BaseBenchmarkDriver
+import dotty.tools.dotc.core.Contexts.ContextBase
+
+trait BenchmarkDriver extends BaseBenchmarkDriver {
+  def compileImpl(): Unit = {
+    implicit val ctx = (new ContextBase).initialCtx.fresh
+    ctx.setSetting(ctx.settings.usejavacp, true)
+    if (depsClasspath != null) {
+      ctx.setSetting(ctx.settings.classpath,
+                     depsClasspath.mkString(File.pathSeparator))
+    }
+    ctx.setSetting(ctx.settings.d, tempDir.getAbsolutePath)
+    ctx.setSetting(ctx.settings.language, List("Scala2"))
+    val compiler = new dotty.tools.dotc.Compiler
+    val reporter =
+      dotty.tools.dotc.Bench.doCompile(compiler, compilerArgs.toList)
+    assert(!reporter.hasErrors)
+  }
+}

--- a/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
@@ -17,6 +17,8 @@ import scala.tools.benchmark.BenchmarkDriver
 trait BaseBenchmarkDriver {
   def source: String
   def extraArgs: String
+  def extras: List[String] = if (extraArgs != null && extraArgs != "") extraArgs.split('|').toList else Nil
+  def allArgs: List[String] = compilerArgs ++ extras ++ sourceFiles
   def corpusVersion: String
   def depsClasspath: String
   def tempDir: File

--- a/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
@@ -140,7 +140,7 @@ object ScalacBenchmarkStandalone {
 @BenchmarkMode(Array(SingleShotTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 // TODO -Xbatch reduces fork-to-fork variance, but incurs 5s -> 30s slowdown
-//@Fork(value = 16, jvmArgs = Array("-XX:CICompilerCount=2", "-Xms2G", "-Xmx2G"))
+@Fork(value = 16, jvmArgs = Array("-XX:CICompilerCount=2", "-Xms2G", "-Xmx2G"))
 class ColdScalacBenchmark extends ScalacBenchmark {
   @Benchmark
   def compile(): Unit = compileImpl()
@@ -152,7 +152,7 @@ class ColdScalacBenchmark extends ScalacBenchmark {
 @Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 // @Fork triggers match error in dotty, see https://github.com/lampepfl/dotty/issues/2704
 // Comment out `@Fork` to run compilation/test with Dotty or wait for that issue to be fixed.
-//@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G"))
+@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G"))
 class WarmScalacBenchmark extends ScalacBenchmark {
   @Benchmark
   def compile(): Unit = compileImpl()
@@ -162,7 +162,7 @@ class WarmScalacBenchmark extends ScalacBenchmark {
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
-//@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G"))
+@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G"))
 class HotScalacBenchmark extends ScalacBenchmark {
   @Benchmark
   def compile(): Unit = compileImpl()

--- a/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
@@ -140,7 +140,7 @@ object ScalacBenchmarkStandalone {
 @BenchmarkMode(Array(SingleShotTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 // TODO -Xbatch reduces fork-to-fork variance, but incurs 5s -> 30s slowdown
-@Fork(value = 16, jvmArgs = Array("-XX:CICompilerCount=2", "-Xms2G", "-Xmx2G"))
+//@Fork(value = 16, jvmArgs = Array("-XX:CICompilerCount=2", "-Xms2G", "-Xmx2G"))
 class ColdScalacBenchmark extends ScalacBenchmark {
   @Benchmark
   def compile(): Unit = compileImpl()
@@ -152,7 +152,7 @@ class ColdScalacBenchmark extends ScalacBenchmark {
 @Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 // @Fork triggers match error in dotty, see https://github.com/lampepfl/dotty/issues/2704
 // Comment out `@Fork` to run compilation/test with Dotty or wait for that issue to be fixed.
-@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G"))
+//@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G"))
 class WarmScalacBenchmark extends ScalacBenchmark {
   @Benchmark
   def compile(): Unit = compileImpl()
@@ -162,7 +162,7 @@ class WarmScalacBenchmark extends ScalacBenchmark {
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G"))
+//@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G"))
 class HotScalacBenchmark extends ScalacBenchmark {
   @Benchmark
   def compile(): Unit = compileImpl()

--- a/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
@@ -121,8 +121,6 @@ class ColdScalacBenchmark extends ScalacBenchmark {
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 0)
 @Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
-// @Fork triggers match error in dotty, see https://github.com/lampepfl/dotty/issues/2704
-// Comment out `@Fork` to run compilation/test with Dotty or wait for that issue to be fixed.
 @Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G"))
 class WarmScalacBenchmark extends ScalacBenchmark {
   @Benchmark

--- a/compilation/src/main/scalac/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/scalac/scala/tools/benchmark/BenchmarkDriver.scala
@@ -24,13 +24,15 @@ trait BenchmarkDriver extends BaseBenchmarkDriver {
         settings.nowarn.value = true
         if (depsClasspath != null)
           settings.processArgumentString(s"-cp $depsClasspath")
-        if (extraArgs != null && extraArgs != "")
-          settings.processArgumentString(extraArgs)
         true
       }
     }
     val driver = new MainClass
-    driver.process(compilerArgs)
+
+    val extras = if (extraArgs != null && extraArgs != "") extraArgs.split('|').toList else Nil
+    val allArgs = compilerArgs ++ extras ++ sourceFiles
+    driver.process(allArgs.toArray)
     assert(!driver.reporter.hasErrors)
   }
+
 }

--- a/compilation/src/main/scalac/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/scalac/scala/tools/benchmark/BenchmarkDriver.scala
@@ -1,0 +1,36 @@
+package scala.tools.benchmark
+
+import java.nio.file._
+import scala.tools.nsc._
+
+trait BenchmarkDriver extends BaseBenchmarkDriver {
+  def compileImpl(): Unit = {
+    // MainClass is copy-pasted from compiler for source compatibility with 2.10.x - 2.13.x
+    class MainClass extends Driver with EvalLoop {
+      def resident(compiler: Global): Unit = loop { line =>
+        val command = new CompilerCommand(line split "\\s+" toList, new Settings(scalacError))
+        compiler.reporter.reset()
+        new compiler.Run() compile command.files
+      }
+
+      override def newCompiler(): Global = Global(settings, reporter)
+
+      override protected def processSettingsHook(): Boolean = {
+        if (source == "scala")
+          settings.sourcepath.value = Paths.get(s"../corpus/$source/$corpusVersion/library").toAbsolutePath.normalize.toString
+        else
+          settings.usejavacp.value = true
+        settings.outdir.value = tempDir.getAbsolutePath
+        settings.nowarn.value = true
+        if (depsClasspath != null)
+          settings.processArgumentString(s"-cp $depsClasspath")
+        if (extraArgs != null && extraArgs != "")
+          settings.processArgumentString(extraArgs)
+        true
+      }
+    }
+    val driver = new MainClass
+    driver.process(compilerArgs)
+    assert(!driver.reporter.hasErrors)
+  }
+}

--- a/compilation/src/main/scalac/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/scalac/scala/tools/benchmark/BenchmarkDriver.scala
@@ -28,9 +28,6 @@ trait BenchmarkDriver extends BaseBenchmarkDriver {
       }
     }
     val driver = new MainClass
-
-    val extras = if (extraArgs != null && extraArgs != "") extraArgs.split('|').toList else Nil
-    val allArgs = compilerArgs ++ extras ++ sourceFiles
     driver.process(allArgs.toArray)
     assert(!driver.reporter.hasErrors)
   }

--- a/compilation/src/test/scala/scala/tools/benchmark/BenchmarkTest.scala
+++ b/compilation/src/test/scala/scala/tools/benchmark/BenchmarkTest.scala
@@ -1,0 +1,9 @@
+package scala.tools.benchmark
+
+import scala.tools.nsc.ScalacBenchmarkStandalone
+import org.junit.Test
+
+class BenchmarkTest {
+  @Test def compilesOK =
+    ScalacBenchmarkStandalone.main(Array("../corpus/vector", "1"))
+}

--- a/compilation/src/test/scala/scala/tools/benchmark/BenchmarkTest.scala
+++ b/compilation/src/test/scala/scala/tools/benchmark/BenchmarkTest.scala
@@ -1,9 +1,15 @@
 package scala.tools.benchmark
 
-import scala.tools.nsc.ScalacBenchmarkStandalone
+import scala.tools.nsc.ScalacBenchmark
 import org.junit.Test
 
 class BenchmarkTest {
-  @Test def compilesOK =
-    ScalacBenchmarkStandalone.main(Array("../corpus/vector", "1"))
+  @Test def compilesOK() = {
+    val bench = new ScalacBenchmark
+    bench.source = "../corpus/vector"
+    bench.corpusVersion = "latest"
+    bench.initTemp()
+    bench.compileImpl()
+    bench.clearTemp()
+  }
 }

--- a/corpus/vector/fb04376/Vector.scala
+++ b/corpus/vector/fb04376/Vector.scala
@@ -82,7 +82,7 @@ override def companion: GenericCompanion[Vector] = Vector
 
   override def lengthCompare(len: Int): Int = length - len
 
-  private[collection] final def initIterator[B >: A](s: VectorIterator[B]) {
+  private[collection] final def initIterator[B >: A](s: VectorIterator[B]): Unit = {
     s.initFrom(this)
     if (dirty) s.stabilize(focus)
     if (s.depth > 1) s.gotoPos(startIndex, startIndex ^ focus)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,6 @@ logLevel := Level.Warn
 
 // sbt-jmh plugin - pulls in JMH dependencies too
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.25")
+
+// sbt-dotty plugin - to support `scalaVersion := "0.x"`
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.1.2")


### PR DESCRIPTION
- `++0.2.0-RC1` to run benchmarks with dotc instead of scalac
- `compilation/test` to quickly check the setup is OK without the need to remember cli args or start slow jmh process.
