### PR TITLE
Support benchmarking of resident compilation

### DIFF
--- a/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
@@ -12,7 +12,7 @@ trait BenchmarkDriver extends BaseBenchmarkDriver {
       ctx.setSetting(ctx.settings.classpath,
                      depsClasspath.mkString(File.pathSeparator))
     }
-    ctx.setSetting(ctx.settings.migration, true)
+    ctx.setSetting(ctx.settings.migration, false)
     ctx.setSetting(ctx.settings.d, tempDir.getAbsolutePath)
     ctx.setSetting(ctx.settings.language, List("Scala2"))
     val compiler = new dotty.tools.dotc.Compiler

--- a/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
@@ -25,6 +25,7 @@ trait BaseBenchmarkDriver {
   def corpusSourcePath: Path
   def compilerArgs: List[String]
   def sourceFiles: List[String]
+  def isResident: Boolean = false
 }
 
 @State(Scope.Benchmark)
@@ -39,6 +40,11 @@ class ScalacBenchmark extends BenchmarkDriver {
   // When running the benchmark directly the "latest" symlink is used.
   @Param(value = Array("latest"))
   var corpusVersion: String = _
+
+  @Param(value = Array("false"))
+  var resident: Boolean = false
+
+  override def isResident = resident
 
   var depsClasspath: String = _
 

--- a/compilation/src/main/scalac/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/scalac/scala/tools/benchmark/BenchmarkDriver.scala
@@ -9,11 +9,6 @@ trait BenchmarkDriver extends BaseBenchmarkDriver {
 
   // MainClass is copy-pasted from compiler for source compatibility with 2.10.x - 2.13.x
   private class MainClass extends Driver with EvalLoop {
-    def resident(compiler: Global): Unit = loop { line =>
-      val command = new CompilerCommand(line split "\\s+" toList, new Settings(scalacError))
-      compiler.reporter.reset()
-      new compiler.Run() compile command.files
-    }
     var compiler: Global = _
     override def newCompiler(): Global = {
       compiler = Global(settings, reporter)

--- a/compilation/src/main/scalac/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/scalac/scala/tools/benchmark/BenchmarkDriver.scala
@@ -4,31 +4,52 @@ import java.nio.file._
 import scala.tools.nsc._
 
 trait BenchmarkDriver extends BaseBenchmarkDriver {
-  def compileImpl(): Unit = {
-    // MainClass is copy-pasted from compiler for source compatibility with 2.10.x - 2.13.x
-    class MainClass extends Driver with EvalLoop {
-      def resident(compiler: Global): Unit = loop { line =>
-        val command = new CompilerCommand(line split "\\s+" toList, new Settings(scalacError))
-        compiler.reporter.reset()
-        new compiler.Run() compile command.files
-      }
+  private var driver: MainClass = _
+  private var files: List[String] = _
 
-      override def newCompiler(): Global = Global(settings, reporter)
-
-      override protected def processSettingsHook(): Boolean = {
-        if (source == "scala")
-          settings.sourcepath.value = Paths.get(s"../corpus/$source/$corpusVersion/library").toAbsolutePath.normalize.toString
-        else
-          settings.usejavacp.value = true
-        settings.outdir.value = tempDir.getAbsolutePath
-        settings.nowarn.value = true
-        if (depsClasspath != null)
-          settings.processArgumentString(s"-cp $depsClasspath")
-        true
-      }
+  // MainClass is copy-pasted from compiler for source compatibility with 2.10.x - 2.13.x
+  private class MainClass extends Driver with EvalLoop {
+    def resident(compiler: Global): Unit = loop { line =>
+      val command = new CompilerCommand(line split "\\s+" toList, new Settings(scalacError))
+      compiler.reporter.reset()
+      new compiler.Run() compile command.files
     }
-    val driver = new MainClass
-    driver.process(allArgs.toArray)
+    var compiler: Global = _
+    override def newCompiler(): Global = {
+      compiler = Global(settings, reporter)
+      compiler
+    }
+
+    override protected def processSettingsHook(): Boolean = {
+      if (source == "scala")
+        settings.sourcepath.value = Paths.get(s"../corpus/$source/$corpusVersion/library").toAbsolutePath.normalize.toString
+      else
+        settings.usejavacp.value = true
+      settings.outdir.value = tempDir.getAbsolutePath
+      settings.nowarn.value = true
+      if (depsClasspath != null)
+        settings.processArgumentString(s"-cp $depsClasspath")
+      true
+    }
+  }
+
+  def compileImpl(): Unit = {
+    if (isResident) {
+      if (driver == null) {
+        driver = new MainClass
+        driver.process(allArgs.toArray)
+        val command  = new CompilerCommand(allArgs, driver.compiler.settings)
+        files = command.files
+      } else {
+        val compiler = driver.compiler
+        compiler.reporter.reset()
+        new compiler.Run() compile files
+      }
+
+    } else {
+      driver = new MainClass
+      driver.process(allArgs.toArray)
+    }
     assert(!driver.reporter.hasErrors)
   }
 


### PR DESCRIPTION
Resident (aka, multi Run) compilation reuses a global, and its symbol table,
for subsequent compilation tasks.

Currently, this mode is only used in the presentation compiler and in the
REPL compiler.

This can lead to significant savings by avoiding re-parsing/-unpickling 
class files. We'd expect this to matter more for small compile batches.

| Corpus       | non-resident | resident |  factor |
|--------------|--------------|----------|---------|
| vector       |    198ms     |   121    |   0.61  |
| better-files |    522       |   360    |   0.69  |
| scalap       |    790       |   720    |   0.91  |

Resident compilation currently doesn't have a good for cache invalidation.
If a JAR or .class file is updated, it should throw away part of the symbol
table and re-read the classes.

The data we gather from these benchmarks will help motivate the [effort](https://github.com/scala/scala-dev/issues/416) to
add this cache invalidation.

It is also worth remembering that reducing the overhead of small compilation
batches is also useful for projects with large codebases. Zinc compiles small
sets of source files in an incremental compilation session.