### PR TITLE
Clean up imports and benchmark NPE exception on path

### DIFF
--- a/compilation/src/main/scala/scala/tools/nsc/HotSbtBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/HotSbtBenchmark.scala
@@ -1,16 +1,11 @@
 package scala.tools.nsc
 
 import java.io._
-import java.net.URL
 import java.nio.file._
-import java.nio.file.attribute.BasicFileAttributes
 import java.util.concurrent.TimeUnit
 
-import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations.Mode.SampleTime
 import org.openjdk.jmh.annotations._
-
-import scala.collection.JavaConverters._
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(SampleTime))

--- a/compilation/src/main/scala/scala/tools/nsc/JavacBenchmark.java
+++ b/compilation/src/main/scala/scala/tools/nsc/JavacBenchmark.java
@@ -1,21 +1,16 @@
 package scala.tools.nsc;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-
-import javax.tools.JavaCompiler;
-import javax.tools.ToolProvider;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 @State(Scope.Thread)
 public class JavacBenchmark {

--- a/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
@@ -1,17 +1,13 @@
 package scala.tools.nsc
 
-import java.io.{File, IOException}
-import java.net.URL
+import java.io.File
 import java.nio.file._
-import java.nio.file.attribute.BasicFileAttributes
 import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 
-import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations.Mode._
 import org.openjdk.jmh.annotations._
 
-import scala.collection.JavaConverters._
 import scala.tools.benchmark.BenchmarkDriver
 
 trait BaseBenchmarkDriver {

--- a/infrastructure/src/main/java/scala/bench/Database.java
+++ b/infrastructure/src/main/java/scala/bench/Database.java
@@ -1,24 +1,21 @@
 package scala.bench;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import okhttp3.Credentials;
-import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-import org.influxdb.InfluxDB;
-import org.influxdb.InfluxDBFactory;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.stream.Stream;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
 
 public class Database {
 

--- a/micro/src/main/scala/scala/tools/nsc/TreeTransformerBenchmark.scala
+++ b/micro/src/main/scala/scala/tools/nsc/TreeTransformerBenchmark.scala
@@ -17,7 +17,7 @@ class TreeTransformerBenchmark {
   var g: Global = _
   var tree: Global#Tree = _
 
-  @Param(Array("../corpus/vector/Vector.scala"))
+  @Param(Array("../corpus/vector/latest/Vector.scala"))
   var file: String = _
 
   @Setup def setup(): Unit = {

--- a/micro/src/main/scala/scala/tools/nsc/TreeTraverserBenchmark.scala
+++ b/micro/src/main/scala/scala/tools/nsc/TreeTraverserBenchmark.scala
@@ -16,7 +16,7 @@ import scala.reflect.internal.util.BatchSourceFile
 class TreeTraverserBenchmark {
   var g: Global = _
   var tree: Global#Tree = _
-  @Param(Array("../corpus/vector/Vector.scala"))
+  @Param(Array("../corpus/vector/latest/Vector.scala"))
   var file: String = _
 
   @Setup def setup(): Unit = {


### PR DESCRIPTION
* Fixed array path in `TreeTransformerBenchmark.scala` && `TreeTraverserBenchmark.scala` that would cause those bench marks to throw NPE due to missing file.

* Cleaned up various unused imports 

```
[compiler-benchmark (adam-singer/clean-up-imports-and-paths)]$ sbt
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
test[info] Loading global plugins from /Users/adams/.sbt/0.13/plugins
All[info] Loading project definition from /Users/adams/workspace/compiler-benchmark/project

[info] Set current project to compiler-benchmark (in build file:/Users/adams/workspace/compiler-benchmark/)
> testAll
[success] Total time: 0 s, completed Sep 16, 2017 10:52:22 PM
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 5 s, completed Sep 16, 2017 10:52:27 PM
[info] Running scala.bench.ScalacBenchmarkRunner HotScalacBenchmark -foe true -psource=scalap -wi 1 -i 1 -f1
[error] Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
[error] Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
[info] # JMH version: 1.19
[info] # VM version: JDK 1.8.0_111, VM 25.111-b14
[info] # VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_111.jdk/Contents/Home/jre/bin/java
[info] # VM options: -Xms2G -Xmx2G
[info] # Warmup: 1 iterations, 10 s each
[info] # Measurement: 1 iterations, 10 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Sampling time
[info] # Benchmark: scala.tools.nsc.HotScalacBenchmark.compile
[info] # Parameters: (corpusVersion = latest, extraArgs = , resident = false, source = scalap)
[info]
[info] # Run progress: 0.00% complete, ETA 00:00:20
[info] # Fork: 1 of 1
[info] Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
[info] Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
[info] # Warmup Iteration   1: 10015.998 ms/op
[info] Iteration   1: 3442.125 ±(99.9%) 8750.167 ms/op
[info]                  compile·p0.00:   3019.899 ms/op
[info]                  compile·p0.50:   3342.860 ms/op
[info]                  compile·p0.90:   3963.617 ms/op
[info]                  compile·p0.95:   3963.617 ms/op
[info]                  compile·p0.99:   3963.617 ms/op
[info]                  compile·p0.999:  3963.617 ms/op
[info]                  compile·p0.9999: 3963.617 ms/op
[info]                  compile·p1.00:   3963.617 ms/op
[info]
[info]
[info]
[info] Result "scala.tools.nsc.HotScalacBenchmark.compile":
[info]   N = 3
[info]   mean =   3442.125 ±(99.9%) 8750.167 ms/op
[info]
[info]   Histogram, ms/op:
[info]     [3000.000, 3100.000) = 1
[info]     [3100.000, 3200.000) = 0
[info]     [3200.000, 3300.000) = 0
[info]     [3300.000, 3400.000) = 1
[info]     [3400.000, 3500.000) = 0
[info]     [3500.000, 3600.000) = 0
[info]     [3600.000, 3700.000) = 0
[info]     [3700.000, 3800.000) = 0
[info]     [3800.000, 3900.000) = 0
[info]
[info]   Percentiles, ms/op:
[info]       p(0.0000) =   3019.899 ms/op
[info]      p(50.0000) =   3342.860 ms/op
[info]      p(90.0000) =   3963.617 ms/op
[info]      p(95.0000) =   3963.617 ms/op
[info]      p(99.0000) =   3963.617 ms/op
[info]      p(99.9000) =   3963.617 ms/op
[info]      p(99.9900) =   3963.617 ms/op
[info]      p(99.9990) =   3963.617 ms/op
[info]      p(99.9999) =   3963.617 ms/op
[info]     p(100.0000) =   3963.617 ms/op
[info]
[info]
[info] # Run complete. Total time: 00:00:21
[info]
[info] Benchmark                                   (corpusVersion)  (extraArgs)  (resident)  (source)    Mode  Cnt     Score      Error  Units
[info] HotScalacBenchmark.compile                           latest                    false    scalap  sample    3  3442.125 ± 8750.167  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00             latest                    false    scalap  sample       3019.899             ms/op
[info] HotScalacBenchmark.compile:compile·p0.50             latest                    false    scalap  sample       3342.860             ms/op
[info] HotScalacBenchmark.compile:compile·p0.90             latest                    false    scalap  sample       3963.617             ms/op
[info] HotScalacBenchmark.compile:compile·p0.95             latest                    false    scalap  sample       3963.617             ms/op
[info] HotScalacBenchmark.compile:compile·p0.99             latest                    false    scalap  sample       3963.617             ms/op
[info] HotScalacBenchmark.compile:compile·p0.999            latest                    false    scalap  sample       3963.617             ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999           latest                    false    scalap  sample       3963.617             ms/op
[info] HotScalacBenchmark.compile:compile·p1.00             latest                    false    scalap  sample       3963.617             ms/op
[success] Total time: 22 s, completed Sep 16, 2017 10:52:49 PM
[info] Setting version to 0.2.0-RC1
[info] Reapplying settings...
[info] Set current project to compiler-benchmark (in build file:/Users/adams/workspace/compiler-benchmark/)
[info] Updating {file:/Users/adams/workspace/compiler-benchmark/}infrastructure...
[info] Resolving ch.epfl.lamp#scala-library;0.2.0-RC1 ...
[warn] circular dependency found: ch.epfl.lamp#dotty-library_0.2;0.2.0-RC1->ch.epfl.lamp#scala-library;0.2.0-RC1->...
[warn] circular dependency found: ch.epfl.lamp#scala-library;0.2.0-RC1->ch.epfl.lamp#dotty-library_0.2;0.2.0-RC1->...
[info] Resolving org.scala-lang.modules#scala-xml_2.11;1.0.1 ...
[info] Done updating.
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn] 	* com.google.guava:guava:20.0 -> 21.0
[warn] Run 'evicted' to see detailed eviction warnings
[info] Updating {file:/Users/adams/workspace/compiler-benchmark/}compilation...
[warn] Binary version (0.2.0-RC1) for dependency ch.epfl.lamp#scala-library;0.2.0-RC1
[warn] 	in compilation#compilation_0.2;0.1-SNAPSHOT differs from Scala binary version in project (0.2).
[info] Resolving ch.epfl.lamp#dotty-library_0.2;0.2.0-RC1 ...
[warn] circular dependency found: ch.epfl.lamp#scala-library;0.2.0-RC1->ch.epfl.lamp#dotty-library_0.2;0.2.0-RC1->...
[warn] circular dependency found: ch.epfl.lamp#dotty-library_0.2;0.2.0-RC1->ch.epfl.lamp#scala-library;0.2.0-RC1->...
[info] Resolving ch.epfl.lamp#dotty_0.2;0.2.0-RC1 ...
[info] Done updating.
[info] Compiling 9 Java sources to /Users/adams/workspace/compiler-benchmark/infrastructure/target/classes...
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
time elapsed: 4554ms
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 8 s, completed Sep 16, 2017 10:52:57 PM
[info] Running scala.bench.ScalacBenchmarkRunner HotScalacBenchmark -foe true -psource=vector -wi 1 -i 1 -f1
[error] Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
[error] Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
[info] # JMH version: 1.19
[info] # VM version: JDK 1.8.0_111, VM 25.111-b14
[info] # VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_111.jdk/Contents/Home/jre/bin/java
[info] # VM options: -Xms2G -Xmx2G
[info] # Warmup: 1 iterations, 10 s each
[info] # Measurement: 1 iterations, 10 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Sampling time
[info] # Benchmark: scala.tools.nsc.HotScalacBenchmark.compile
[info] # Parameters: (corpusVersion = latest, extraArgs = , resident = false, source = vector)
[info]
[info] # Run progress: 0.00% complete, ETA 00:00:20
[info] # Fork: 1 of 1
[info] Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
[info] Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
[info] # Warmup Iteration   1: time elapsed: 4514ms
[info] time elapsed: 1631ms
[info] time elapsed: 1144ms
[info] time elapsed: 923ms
[info] time elapsed: 933ms
[info] time elapsed: 790ms
[info] 1713.198 ±(99.9%) 4386.693 ms/op
[info] Iteration   1: time elapsed: 795ms
[info] time elapsed: 765ms
[info] time elapsed: 675ms
[info] time elapsed: 689ms
[info] time elapsed: 736ms
[info] time elapsed: 620ms
[info] time elapsed: 743ms
[info] time elapsed: 587ms
[info] time elapsed: 573ms
[info] time elapsed: 578ms
[info] time elapsed: 566ms
[info] time elapsed: 536ms
[info] time elapsed: 514ms
[info] time elapsed: 515ms
[info] time elapsed: 510ms
[info] time elapsed: 513ms
[info] time elapsed: 577ms
[info] 618.166 ±(99.9%) 94.397 ms/op
[info]                  compile·p0.00:   511.181 ms/op
[info]                  compile·p0.50:   578.814 ms/op
[info]                  compile·p0.90:   772.381 ms/op
[info]                  compile·p0.95:   795.869 ms/op
[info]                  compile·p0.99:   795.869 ms/op
[info]                  compile·p0.999:  795.869 ms/op
[info]                  compile·p0.9999: 795.869 ms/op
[info]                  compile·p1.00:   795.869 ms/op
[info]
[info]
[info]
[info] Result "scala.tools.nsc.HotScalacBenchmark.compile":
[info]   N = 17
[info]   mean =    618.166 ±(99.9%) 94.397 ms/op
[info]
[info]   Histogram, ms/op:
[info]     [500.000, 525.000) = 4
[info]     [525.000, 550.000) = 1
[info]     [550.000, 575.000) = 2
[info]     [575.000, 600.000) = 3
[info]     [600.000, 625.000) = 1
[info]     [625.000, 650.000) = 0
[info]     [650.000, 675.000) = 0
[info]     [675.000, 700.000) = 2
[info]     [700.000, 725.000) = 0
[info]     [725.000, 750.000) = 2
[info]     [750.000, 775.000) = 1
[info]
[info]   Percentiles, ms/op:
[info]       p(0.0000) =    511.181 ms/op
[info]      p(50.0000) =    578.814 ms/op
[info]      p(90.0000) =    772.381 ms/op
[info]      p(95.0000) =    795.869 ms/op
[info]      p(99.0000) =    795.869 ms/op
[info]      p(99.9000) =    795.869 ms/op
[info]      p(99.9900) =    795.869 ms/op
[info]      p(99.9990) =    795.869 ms/op
[info]      p(99.9999) =    795.869 ms/op
[info]     p(100.0000) =    795.869 ms/op
[info]
[info]
[info] # Run complete. Total time: 00:00:21
[info]
[info] Benchmark                                   (corpusVersion)  (extraArgs)  (resident)  (source)    Mode  Cnt    Score    Error  Units
[info] HotScalacBenchmark.compile                           latest                    false    vector  sample   17  618.166 ± 94.397  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00             latest                    false    vector  sample       511.181           ms/op
[info] HotScalacBenchmark.compile:compile·p0.50             latest                    false    vector  sample       578.814           ms/op
[info] HotScalacBenchmark.compile:compile·p0.90             latest                    false    vector  sample       772.381           ms/op
[info] HotScalacBenchmark.compile:compile·p0.95             latest                    false    vector  sample       795.869           ms/op
[info] HotScalacBenchmark.compile:compile·p0.99             latest                    false    vector  sample       795.869           ms/op
[info] HotScalacBenchmark.compile:compile·p0.999            latest                    false    vector  sample       795.869           ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999           latest                    false    vector  sample       795.869           ms/op
[info] HotScalacBenchmark.compile:compile·p1.00             latest                    false    vector  sample       795.869           ms/op
[success] Total time: 22 s, completed Sep 16, 2017 10:53:20 PM
[info] Setting version to 2.11.11
[info] Reapplying settings...
[info] Set current project to compiler-benchmark (in build file:/Users/adams/workspace/compiler-benchmark/)
[info] Updating {file:/Users/adams/workspace/compiler-benchmark/}infrastructure...
[info] Resolving jline#jline;2.14.3 ...
[info] Done updating.
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn] 	* com.google.guava:guava:20.0 -> 21.0
[warn] Run 'evicted' to see detailed eviction warnings
[info] Updating {file:/Users/adams/workspace/compiler-benchmark/}micro...
[info] Resolving jline#jline;2.14.3 ...
[info] Done updating.
[info] Compiling 9 Java sources to /Users/adams/workspace/compiler-benchmark/infrastructure/target/classes...
[info] Running org.openjdk.jmh.Main -w1 -f1
[error] Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
[error] Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
[info] # JMH version: 1.19
[info] # VM version: JDK 1.8.0_111, VM 25.111-b14
[info] # VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_111.jdk/Contents/Home/jre/bin/java
[info] # VM options: -Dfile.encoding=utf8 -DscalaVersion=2.11.11 -DscalaRef=v2.11.11 -Dsbt.launcher=/opt/twitter/Cellar/sbt/0.13.8/libexec/sbt-launch.jar -Djava.net.preferIPv4Stack=true
[info] # Warmup: 10 iterations, 1 s each
[info] # Measurement: 10 iterations, 1 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Throughput, ops/time
[info] # Benchmark: scala.tools.nsc.TreeTransformerBenchmark.measure
[info] # Parameters: (file = ../corpus/vector/latest/Vector.scala)
[info]
[info] # Run progress: 0.00% complete, ETA 00:00:40
[info] # Fork: 1 of 1
[info] Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
[info] Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
[info] # Warmup Iteration   1: 2136.856 ops/s
[info] # Warmup Iteration   2: 3354.918 ops/s
[info] # Warmup Iteration   3: 3489.142 ops/s
[info] # Warmup Iteration   4: 3555.690 ops/s
[info] # Warmup Iteration   5: 3253.795 ops/s
[info] # Warmup Iteration   6: 3549.362 ops/s
[info] # Warmup Iteration   7: 3638.344 ops/s
[info] # Warmup Iteration   8: 3442.823 ops/s
[info] # Warmup Iteration   9: 3573.406 ops/s
[info] # Warmup Iteration  10: 3611.763 ops/s
[info] Iteration   1: 3836.905 ops/s
[info] Iteration   2: 3789.770 ops/s
[info] Iteration   3: 3681.615 ops/s
[info] Iteration   4: 3731.797 ops/s
[info] Iteration   5: 3694.771 ops/s
[info] Iteration   6: 3626.015 ops/s
[info] Iteration   7: 3778.186 ops/s
[info] Iteration   8: 3793.016 ops/s
[info] Iteration   9: 3809.310 ops/s
[info] Iteration  10: 3577.408 ops/s
[info]
[info]
[info] Result "scala.tools.nsc.TreeTransformerBenchmark.measure":
[info]   3731.879 ±(99.9%) 128.712 ops/s [Average]
[info]   (min, avg, max) = (3577.408, 3731.879, 3836.905), stdev = 85.135
[info]   CI (99.9%): [3603.168, 3860.591] (assumes normal distribution)
[info]
[info]
[info] # JMH version: 1.19
[info] # VM version: JDK 1.8.0_111, VM 25.111-b14
[info] # VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_111.jdk/Contents/Home/jre/bin/java
[info] # VM options: -Dfile.encoding=utf8 -DscalaVersion=2.11.11 -DscalaRef=v2.11.11 -Dsbt.launcher=/opt/twitter/Cellar/sbt/0.13.8/libexec/sbt-launch.jar -Djava.net.preferIPv4Stack=true
[info] # Warmup: 10 iterations, 1 s each
[info] # Measurement: 10 iterations, 1 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Throughput, ops/time
[info] # Benchmark: scala.tools.nsc.TreeTraverserBenchmark.measure
[info] # Parameters: (file = ../corpus/vector/latest/Vector.scala)
[info]
[info] # Run progress: 50.00% complete, ETA 00:00:23
[info] # Fork: 1 of 1
[info] Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
[info] Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
[info] # Warmup Iteration   1: 1308.528 ops/s
[info] # Warmup Iteration   2: 1484.774 ops/s
[info] # Warmup Iteration   3: 1341.673 ops/s
[info] # Warmup Iteration   4: 1497.010 ops/s
[info] # Warmup Iteration   5: 1443.173 ops/s
[info] # Warmup Iteration   6: 1484.321 ops/s
[info] # Warmup Iteration   7: 1513.583 ops/s
[info] # Warmup Iteration   8: 1486.945 ops/s
[info] # Warmup Iteration   9: 1454.878 ops/s
[info] # Warmup Iteration  10: 1467.914 ops/s
[info] Iteration   1: 1463.746 ops/s
[info] Iteration   2: 1541.938 ops/s
[info] Iteration   3: 1519.315 ops/s
[info] Iteration   4: 1509.087 ops/s
[info] Iteration   5: 1524.792 ops/s
[info] Iteration   6: 1492.474 ops/s
[info] Iteration   7: 1442.853 ops/s
[info] Iteration   8: 1507.499 ops/s
[info] Iteration   9: 1529.563 ops/s
[info] Iteration  10: 1463.401 ops/s
[info]
[info]
[info] Result "scala.tools.nsc.TreeTraverserBenchmark.measure":
[info]   1499.467 ±(99.9%) 49.717 ops/s [Average]
[info]   (min, avg, max) = (1442.853, 1499.467, 1541.938), stdev = 32.885
[info]   CI (99.9%): [1449.750, 1549.184] (assumes normal distribution)
[info]
[info]
[info] # Run complete. Total time: 00:00:46
[info]
[info] Benchmark                                                       (file)   Mode  Cnt     Score     Error  Units
[info] TreeTransformerBenchmark.measure  ../corpus/vector/latest/Vector.scala  thrpt   10  3731.879 ± 128.712  ops/s
[info] TreeTraverserBenchmark.measure    ../corpus/vector/latest/Vector.scala  thrpt   10  1499.467 ±  49.717  ops/s
[success] Total time: 48 s, completed Sep 16, 2017 10:54:09 PM
```