### PR TITLE
Version Bump Party

### DIFF
--- a/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
@@ -13,7 +13,7 @@ trait BenchmarkDriver extends BaseBenchmarkDriver {
                      depsClasspath.mkString(File.pathSeparator))
     }
     ctx.setSetting(ctx.settings.migration, false)
-    ctx.setSetting(ctx.settings.d, tempDir.getAbsolutePath)
+    ctx.setSetting(ctx.settings.outputDir, tempDir.getAbsolutePath)
     ctx.setSetting(ctx.settings.language, List("Scala2"))
     val compiler = new dotty.tools.dotc.Compiler
     val reporter = dotty.tools.dotc.Bench.doCompile(compiler, allArgs)

--- a/compilation/src/main/scala/scala/tools/nsc/HotSbtBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/HotSbtBenchmark.scala
@@ -4,11 +4,11 @@ import java.io._
 import java.nio.file._
 import java.util.concurrent.TimeUnit
 
-import org.openjdk.jmh.annotations.Mode.SampleTime
+import org.openjdk.jmh.annotations.Mode
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Benchmark)
-@BenchmarkMode(Array(SampleTime))
+@BenchmarkMode(Array(org.openjdk.jmh.annotations.Mode.SampleTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)

--- a/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
@@ -111,7 +111,7 @@ object ScalacBenchmarkStandalone {
 }
 
 @State(Scope.Benchmark)
-@BenchmarkMode(Array(SingleShotTime))
+@BenchmarkMode(Array(org.openjdk.jmh.annotations.Mode.SingleShotTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 // TODO -Xbatch reduces fork-to-fork variance, but incurs 5s -> 30s slowdown
 @Fork(value = 16, jvmArgs = Array("-XX:CICompilerCount=2", "-Xms2G", "-Xmx2G"))
@@ -120,7 +120,7 @@ class ColdScalacBenchmark extends ScalacBenchmark {
   def compile(): Unit = compileImpl()
 }
 
-@BenchmarkMode(Array(SampleTime))
+@BenchmarkMode(Array(org.openjdk.jmh.annotations.Mode.SampleTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 0)
 @Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
@@ -130,7 +130,7 @@ class WarmScalacBenchmark extends ScalacBenchmark {
   def compile(): Unit = compileImpl()
 }
 
-@BenchmarkMode(Array(SampleTime))
+@BenchmarkMode(Array(org.openjdk.jmh.annotations.Mode.SampleTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.1.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 logLevel := Level.Warn
 
 // sbt-jmh plugin - pulls in JMH dependencies too
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.0")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
 
 // sbt-dotty plugin - to support `scalaVersion := "0.x"`
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.1.2")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.2.2")


### PR DESCRIPTION
Upgrade to the latest Scala, SBT, sbt-jmh and Dotty versions.

Workaround https://github.com/lampepfl/dotty/issues/4551 by
qualifying annotation arguments.