### PR TITLE
Make scala corpus less cycle prone

### DIFF
--- a/corpus/scala/21d12e9/compiler/scala/tools/reflect/ReflectGlobal.scala
+++ b/corpus/scala/21d12e9/compiler/scala/tools/reflect/ReflectGlobal.scala
@@ -27,7 +27,7 @@ class ReflectGlobal(currentSettings: Settings, reporter: Reporter, override val 
     }
   }
 
-  override def transformedType(sym: Symbol) =
+  override def transformedType(sym: Symbol): Type =
     postErasure.transformInfo(sym,
       erasure.transformInfo(sym,
         uncurry.transformInfo(sym, sym.info)))

--- a/corpus/scala/21d12e9/reflect/scala/reflect/internal/transform/Transforms.scala
+++ b/corpus/scala/21d12e9/reflect/scala/reflect/internal/transform/Transforms.scala
@@ -31,12 +31,12 @@ trait Transforms { self: SymbolTable =>
   def erasure = erasureLazy.force
   def postErasure = postErasureLazy.force
 
-  def transformedType(sym: Symbol) =
+  def transformedType(sym: Symbol): Type =
     postErasure.transformInfo(sym,
       erasure.transformInfo(sym,
         uncurry.transformInfo(sym, sym.info)))
 
-  def transformedType(tpe: Type) =
+  def transformedType(tpe: Type): Type =
     postErasure.elimErasedValueType(erasure.scalaErasure(uncurry.uncurry(tpe)))
 
 }


### PR DESCRIPTION
The compiler from https://github.com/scala/scala/pull/6871 hits a cyclic
reference error.

https://github.com/scala/scala/pull/6871#issuecomment-410147358

Work around this by adding explicit types.