### PR TITLE
Add ioobe method to scala.runtime

### DIFF
--- a/corpus/scala/21d12e9/library/scala/runtime/Statics.java
+++ b/corpus/scala/21d12e9/library/scala/runtime/Statics.java
@@ -116,4 +116,13 @@ public final class Statics {
   }
 
   public static void releaseFence() {}
+
+  /**
+   * Just throws an exception.
+   * Used by the synthetic `productElement` and `productElementName` methods in case classes.
+   * Delegating the exception-throwing to this function reduces the bytecode size of the case class.
+   */
+  public static final <T> T ioobe(int n) throws IndexOutOfBoundsException {
+    throw new IndexOutOfBoundsException(String.valueOf(n));
+  }
 }


### PR DESCRIPTION
We should fix the lookup of this method in Definitions to be tolerant
of its absence, but to get the benchmark back up and running quickly
I'm also adding it here.