### PR TITLE
Restore 2.12/2.13 cross-buildability for the scala corpus

### DIFF
--- a/corpus/scala/df29ebb/compiler/scala/reflect/macros/runtime/JavaReflectionRuntimes.scala
+++ b/corpus/scala/df29ebb/compiler/scala/reflect/macros/runtime/JavaReflectionRuntimes.scala
@@ -31,7 +31,7 @@ trait JavaReflectionRuntimes {
             bundleCtor.newInstance(args.c)
           } else ReflectionUtils.staticSingletonInstance(implClass)
         val implArgs = if (isBundle) args.others else args.c +: args.others
-        implMeth.invoke(implObj, implArgs.asInstanceOf[Seq[AnyRef]]: _*)
+        implMeth.invoke(implObj, implArgs.asInstanceOf[Seq[AnyRef]].toList: _*)
       }
     }
   }

--- a/corpus/scala/df29ebb/compiler/scala/tools/nsc/Global.scala
+++ b/corpus/scala/df29ebb/compiler/scala/tools/nsc/Global.scala
@@ -859,7 +859,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       informProgress(s"classpath updated on entries [${subst.keys mkString ","}]")
       def mkClassPath(elems: Iterable[ClassPath]): ClassPath =
         if (elems.size == 1) elems.head
-        else AggregateClassPath.createAggregate(elems.toSeq: _*)
+        else AggregateClassPath.createAggregate(elems.toList: _*)
       val oldEntries = mkClassPath(subst.keys)
       val newEntries = mkClassPath(subst.values)
       classPath match {
@@ -1205,7 +1205,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       val inclusions = ss.visibleSettings collect {
         case s: ss.PhasesSetting if !(exclusions contains s) => s.value
       }
-      checkPhaseSettings(including = true, inclusions.toSeq: _*)
+      checkPhaseSettings(including = true, inclusions.toList: _*)
       checkPhaseSettings(including = false, exclusions map (_.value): _*)
 
       phase = first   //parserPhase

--- a/corpus/scala/df29ebb/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
+++ b/corpus/scala/df29ebb/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
@@ -59,7 +59,7 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
 
   override def asClassPathStrings: Seq[String] = aggregates.map(_.asClassPathString).distinct
 
-  override def asSourcePathString: String = ClassPath.join(aggregates map (_.asSourcePathString): _*)
+  override def asSourcePathString: String = ClassPath.join(aggregates.map(_.asSourcePathString).toList: _*)
 
   override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
     val aggregatedPackages = aggregates.flatMap(_.packages(inPackage)).distinct
@@ -84,7 +84,7 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
       }
     }.unzip
     val distinctPackages = packages.flatten.distinct
-    val distinctClassesAndSources = mergeClassesAndSources(classesAndSources: _*)
+    val distinctClassesAndSources = mergeClassesAndSources(classesAndSources.toList: _*)
     ClassPathEntries(distinctPackages, distinctClassesAndSources)
   }
 

--- a/corpus/scala/df29ebb/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/corpus/scala/df29ebb/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -155,8 +155,8 @@ trait Logic extends Debugging  {
       implicit val SymOrdering: Ordering[Sym] = Ordering.by(_.id)
     }
 
-    def /\(props: Iterable[Prop]) = if (props.isEmpty) True else And(props.toSeq: _*)
-    def \/(props: Iterable[Prop]) = if (props.isEmpty) False else Or(props.toSeq: _*)
+    def /\(props: Iterable[Prop]) = if (props.isEmpty) True else And(props.toList: _*)
+    def \/(props: Iterable[Prop]) = if (props.isEmpty) False else Or(props.toList: _*)
 
     /**
      * Simplifies propositional formula according to the following rules:
@@ -219,7 +219,7 @@ trait Logic extends Debugging  {
             opsFlattened match {
               case Seq()  => True
               case Seq(f) => f
-              case ops    => And(ops: _*)
+              case ops    => And(ops.toList: _*)
             }
           }
         case Or(fv)      =>
@@ -237,7 +237,7 @@ trait Logic extends Debugging  {
             opsFlattened match {
               case Seq()  => False
               case Seq(f) => f
-              case ops    => Or(ops: _*)
+              case ops    => Or(ops.toList: _*)
             }
           }
         case Not(Not(a)) =>
@@ -406,7 +406,7 @@ trait Logic extends Debugging  {
 
       if (Statistics.canEnable) Statistics.stopTimer(patmatAnaVarEq, start)
 
-      (And(eqAxioms: _*), pure)
+      (And(eqAxioms.toList: _*), pure)
     }
 
     type Solvable

--- a/corpus/scala/df29ebb/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/corpus/scala/df29ebb/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -489,7 +489,7 @@ trait MatchAnalysis extends MatchApproximation {
           else {
             prefix += prefHead
             current = current.tail
-          val and = And((current.head +: prefix): _*)
+          val and = And((current.head +: prefix).toList: _*)
           val model = findModelFor(eqFreePropToSolvable(and))
 
             // debug.patmat("trying to reach:\n"+ cnfString(current.head) +"\nunder prefix:\n"+ cnfString(prefix))

--- a/corpus/scala/df29ebb/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/corpus/scala/df29ebb/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -50,7 +50,7 @@ trait ClassPath {
 
   /** The whole classpath in the form of one String.
     */
-  def asClassPathString: String = ClassPath.join(asClassPathStrings: _*)
+  def asClassPathString: String = ClassPath.join(asClassPathStrings.toList: _*)
   // for compatibility purposes
   @deprecated("use asClassPathString instead of this one", "2.11.5")
   def asClasspathString: String = asClassPathString

--- a/corpus/scala/df29ebb/library/scala/Predef.scala
+++ b/corpus/scala/df29ebb/library/scala/Predef.scala
@@ -599,4 +599,6 @@ private[scala] abstract class LowPriorityImplicits {
       def apply(from: String) = immutable.IndexedSeq.newBuilder[T]
       def apply() = immutable.IndexedSeq.newBuilder[T]
     }
+
+   def copyArrayToImmutableIndexedSeq[T](xs: Array[T]): IndexedSeq[T] = ???
 }

--- a/corpus/scala/df29ebb/library/scala/collection/parallel/ParIterableLike.scala
+++ b/corpus/scala/df29ebb/library/scala/collection/parallel/ParIterableLike.scala
@@ -1286,7 +1286,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
     override def split = {
       val pits = pit.splitWithSignalling
       val sizes = pits.map(_.remaining)
-      val opits = othpit.psplitWithSignalling(sizes: _*)
+      val opits = othpit.psplitWithSignalling(sizes.toList: _*)
       (pits zip opits) map { p => new Zip(pbf, p._1, p._2) }
     }
     override def merge(that: Zip[U, S, That]) = result = result combine that.result
@@ -1302,7 +1302,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
     override def split = if (pit.remaining <= len) {
       val pits = pit.splitWithSignalling
       val sizes = pits.map(_.remaining)
-      val opits = othpit.psplitWithSignalling(sizes: _*)
+      val opits = othpit.psplitWithSignalling(sizes.toList: _*)
       ((pits zip opits) zip sizes) map { t => new ZipAll(t._2, thiselem, thatelem, pbf, t._1._1, t._1._2) }
     } else {
       val opits = othpit.psplitWithSignalling(pit.remaining)

--- a/corpus/scala/df29ebb/library/scala/collection/parallel/RemainsIterator.scala
+++ b/corpus/scala/df29ebb/library/scala/collection/parallel/RemainsIterator.scala
@@ -504,7 +504,7 @@ self =>
     def split: Seq[IterableSplitter[(T, S)]] = {
       val selfs = self.split
       val sizes = selfs.map(_.remaining)
-      val thats = that.psplit(sizes: _*)
+      val thats = that.psplit(sizes.toList: _*)
       (selfs zip thats) map { p => p._1 zipParSeq p._2 }
     }
   }

--- a/corpus/scala/df29ebb/library/scala/runtime/ScalaRunTime.scala
+++ b/corpus/scala/df29ebb/library/scala/runtime/ScalaRunTime.scala
@@ -257,6 +257,18 @@ object ScalaRunTime {
       case _: UnsupportedOperationException | _: AssertionError => "" + arg
     }
   }
+  type ArraySeq[T] = Seq[T]
+  def genericWrapArray[T](xs: Array[T]): ArraySeq[T] = ???
+  def wrapRefArray[T <: AnyRef](xs: Array[T]): ArraySeq[T] = ???
+  def wrapIntArray(xs: Array[Int]): ArraySeq[Int] = ???
+  def wrapDoubleArray(xs: Array[Double]): ArraySeq[Double] = ???
+  def wrapLongArray(xs: Array[Long]): ArraySeq[Long] = ???
+  def wrapFloatArray(xs: Array[Float]): ArraySeq[Float] = ???
+  def wrapCharArray(xs: Array[Char]): ArraySeq[Char] = ???
+  def wrapByteArray(xs: Array[Byte]): ArraySeq[Byte] = ???
+  def wrapShortArray(xs: Array[Short]): ArraySeq[Short] = ???
+  def wrapBooleanArray(xs: Array[Boolean]): ArraySeq[Boolean] = ???
+  def wrapUnitArray(xs: Array[Unit]): ArraySeq[Unit] = ???
 
   /** stringOf formatted for use in a repl result. */
   def replStringOf(arg: Any, maxElements: Int): String = {

--- a/corpus/scala/df29ebb/library/scala/sys/package.scala
+++ b/corpus/scala/df29ebb/library/scala/sys/package.scala
@@ -58,7 +58,7 @@ package object sys {
    *
    *  @return   a Map containing the system environment variables.
    */
-  def env: immutable.Map[String, String] = immutable.Map(System.getenv().asScala.toSeq: _*)
+  def env: immutable.Map[String, String] = immutable.Map(System.getenv().asScala.toList: _*)
 
   /** Register a shutdown hook to be run when the VM exits.
    *  The hook is automatically registered: the returned value can be ignored,

--- a/corpus/scala/df29ebb/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/corpus/scala/df29ebb/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -332,9 +332,9 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
       lazy val jconstr = ensureAccessible(constructorToJava(symbol))
 
       def jinvokeraw(args: Seq[Any]) =
-        if (!symbol.isConstructor) jmeth.invoke(receiver, args.asInstanceOf[Seq[AnyRef]]: _*)
-        else if (receiver == null) jconstr.newInstance(args.asInstanceOf[Seq[AnyRef]]: _*)
-        else jconstr.newInstance((receiver +: args).asInstanceOf[Seq[AnyRef]]: _*)
+        if (!symbol.isConstructor) jmeth.invoke(receiver, args.asInstanceOf[Seq[AnyRef]].toList: _*)
+        else if (receiver == null) jconstr.newInstance(args.asInstanceOf[Seq[AnyRef]].toList: _*)
+        else jconstr.newInstance((receiver +: args).asInstanceOf[Seq[AnyRef]].toList: _*)
       def jinvoke(args: Seq[Any]): Any = {
         val result = jinvokeraw(args)
         if (!symbol.isConstructor && jmeth.getReturnType == java.lang.Void.TYPE) ()
@@ -469,7 +469,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
           val jmeths = classOf[BoxesRunTime].getDeclaredMethods.filter(_.getName == nme.primitiveMethodName(symbol.name).toString)
           assert(jmeths.length == 1, jmeths.toList)
           val jmeth = jmeths.head
-          val result = jmeth.invoke(null, (objReceiver +: objArgs).asInstanceOf[Seq[AnyRef]]: _*)
+          val result = jmeth.invoke(null, (objReceiver +: objArgs).asInstanceOf[Seq[AnyRef]].toList: _*)
           if (jmeth.getReturnType == java.lang.Void.TYPE) ()
           else result
         }


### PR DESCRIPTION
Necessary after the transitional support for the old collections
was removed from 2.13.x compiler:

https://github.com/scala/scala/pull/8517