### PR TITLE
Fix Dotty classpath

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "compiler-benchmark"
 version := "1.0-SNAPSHOT"
 
 def scala212 = "2.12.8"
-def dottyLatest = "0.21.0-RC1"
+def dottyLatest = "0.22.0-RC1"
 scalaVersion in ThisBuild := scala212
 val JmhConfig = config("jmh")
 

--- a/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
+++ b/compilation/src/main/dotc/scala/tools/benchmark/BenchmarkDriver.scala
@@ -9,8 +9,7 @@ trait BenchmarkDriver extends BaseBenchmarkDriver {
     implicit val ctx = new ContextBase().initialCtx.fresh
     ctx.setSetting(ctx.settings.usejavacp, true)
     if (depsClasspath != null) {
-      ctx.setSetting(ctx.settings.classpath,
-                     depsClasspath.mkString(File.pathSeparator))
+      ctx.setSetting(ctx.settings.classpath, depsClasspath)
     }
     ctx.setSetting(ctx.settings.migration, false)
     ctx.setSetting(ctx.settings.outputDir, dotty.tools.io.AbstractFile.getDirectory(tempDir.getAbsolutePath))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 
 // sbt-dotty plugin - to support `scalaVersion := "0.x"`
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.4")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.0")


### PR DESCRIPTION
`depsClasspath` is already a classpath string, so interpolating `:` results in classpath arguments like this :smile::

```
/:h:o:m:e:/:t:r:a:v:i:s:/:.:c:o:m:p:i:l:e:r:B:e:n:c:h:m:a:r:k:/:d:e:p:s:/:c:a:t:s:-:k:e:r:n:e:l:_:2:.:1:3:-:2:.:1:.:1:.:j:a:r
```

I've also bumped `dottyLatest` and the sbt-dotty version, but would be happy to split that out into a separate PR or drop it.