### PR TITLE
Avoid SBT's new multi-command parser from eating our ;

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "compiler-benchmark"
 
 version := "1.0-SNAPSHOT"
 
-def scala212 = "2.12.8"
+def scala212 = "2.12.11"
 def dottyLatest = "0.22.0-RC1"
 scalaVersion in ThisBuild := scala212
 val JmhConfig = config("jmh")

--- a/project/Profilers.scala
+++ b/project/Profilers.scala
@@ -39,7 +39,9 @@ case object jfr extends Profiler("jfr") {
 }
 sealed abstract class async(event: String) extends Profiler("async-" + event) {
   val framebuf = 33554432
-  def command(outDir: File): String = s"-prof jmh.extras.Async:dir=${outDir.getAbsolutePath};flameGraphOpts=$flameGraphOpts;verbose=true;event=$event;framebuf=$framebuf" // + ";simplename=true" TODO add this after upgrading next sbt-jmh release
+  def command(outDir: File): String = {
+    s"""-prof "jmh.extras.Async:dir=${outDir.getAbsolutePath};flameGraphOpts=$flameGraphOpts;verbose=true;event=$event;framebuf=${framebuf}" """
+  } // + ";simplename=true" TODO add this after upgrading next sbt-jmh release
 }
 case object asyncCpu extends async("cpu")
 case object asyncAlloc extends async("alloc")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.3.7
+sbt.version=1.3.10
 


### PR DESCRIPTION
In "sbt -prof jmh.extras.Async:k1=v2;k2=v2"

Wrapping a string in "" seems to do the trick.

See:

https://github.com/sbt/sbt/commit/4281972f1a3232d1c2eb76e1197bbb02a142993a#diff-5ea3e43b30fced51c192853005d2c0f7 
https://github.com/sbt/sbt/commit/51d986d751866491acf408ca7882b48abeecd06d#diff-5ea3e43b30fced51c192853005d2c0f7