### PR TITLE
Separate javac benchmark to a subproject to sidestep JPMS issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,15 @@ lazy val compilation = addJmh(project).settings(
   fork in (Test, test) := true // jmh scoped tasks run with fork := true.
 ).settings(addJavaOptions).dependsOn(infrastructure)
 
+lazy val javaCompilation = addJmh(project).settings(
+  description := "Black box benchmark of the java compiler",
+  crossPaths := false,
+  mainClass in (Jmh, run) := Some("scala.bench.ScalacBenchmarkRunner"),
+  libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
+  testOptions in Test += Tests.Argument(TestFrameworks.JUnit),
+  fork in (Test, test) := true // jmh scoped tasks run with fork := true.
+).settings(addJavaOptions).dependsOn(infrastructure)
+
 lazy val micro = addJmh(project).settings(
   description := "Finer grained benchmarks of compiler internals",
   libraryDependencies += scalaOrganization.value % "scala-compiler" % scalaVersion.value

--- a/compilation/src/main/scala/scala/tools/nsc/HotSbtBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/HotSbtBenchmark.scala
@@ -3,9 +3,10 @@ package scala.tools.nsc
 import java.io._
 import java.nio.file._
 import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations.Mode
 import org.openjdk.jmh.annotations._
+
+import scala.bench.IOUtils
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(org.openjdk.jmh.annotations.Mode.SampleTime))
@@ -166,7 +167,7 @@ class HotSbtBenchmark {
   @TearDown(Level.Trial) def terminate(): Unit = {
     processOutputReader.close()
     sbtProcess.destroyForcibly()
-    BenchmarkUtils.deleteRecursive(tempDir)
-    BenchmarkUtils.deleteRecursive(scalaHome)
+    IOUtils.deleteRecursive(tempDir)
+    IOUtils.deleteRecursive(scalaHome)
   }
 }

--- a/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
+++ b/compilation/src/main/scala/scala/tools/nsc/ScalacBenchmark.scala
@@ -3,12 +3,13 @@ package scala.tools.nsc
 import java.io.File
 import java.nio.file._
 import java.util.concurrent.TimeUnit
-
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations.Mode._
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.profile.AsyncProfiler
+import org.openjdk.jmh.runner.Runner
 
+import scala.bench.IOUtils
 import scala.tools.benchmark.BenchmarkDriver
 
 trait BaseBenchmarkDriver {
@@ -73,7 +74,7 @@ class ScalacBenchmark extends BenchmarkDriver {
     else {
       val sourceDir = findSourceDir
       val sourceAssemblyDir = Paths.get(ConfigFactory.load.getString("sourceAssembly.localdir"))
-      BenchmarkUtils.deleteRecursive(sourceAssemblyDir)
+      IOUtils.deleteRecursive(sourceAssemblyDir)
       BenchmarkUtils.prepareSources(sourceDir, sourceAssemblyDir, scalaVersion)
     }
 
@@ -159,4 +160,16 @@ class WarmScalacBenchmark extends ScalacBenchmark {
 class HotScalacBenchmark extends ScalacBenchmark {
   @Benchmark
   def compile(): Unit = compileProfiled()
+}
+
+object BakeOff {
+  def main(args: Array[String]): Unit = {
+    import org.openjdk.jmh.runner.options.Options
+    import org.openjdk.jmh.runner.options.OptionsBuilder
+    import org.openjdk.jmh.runner.options.TimeValue
+    import org.openjdk.jmh.runner.options.VerboseMode
+    val baseOpts = new OptionsBuilder().include(classOf[HotScalacBenchmark].getName).warmupTime(TimeValue.milliseconds(200)).measurementTime(TimeValue.milliseconds(200)).warmupIterations(5).measurementIterations(5).forks(2).verbosity(VerboseMode.SILENT).build
+    new OptionsBuilder().parent(baseOpts).jvmArgsPrepend("-classpath", "-")
+    new Runner(baseOpts)
+  }
 }

--- a/infrastructure/src/main/java/scala/bench/IOUtils.java
+++ b/infrastructure/src/main/java/scala/bench/IOUtils.java
@@ -1,0 +1,28 @@
+package scala.bench;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public abstract class IOUtils {
+    private IOUtils() {}
+
+    public static void deleteRecursive(Path directory) throws IOException {
+        if (Files.exists(directory)) {
+            Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+    }
+}

--- a/javaCompilation/src/main/scala/scala/tools/nsc/JavacBenchmark.java
+++ b/javaCompilation/src/main/scala/scala/tools/nsc/JavacBenchmark.java
@@ -97,8 +97,7 @@ public class JavacBenchmark {
         tempFile.mkdir();
         tempDir = tempFile;
     }
-    @TearDown(Level.Trial) public void clearTemp() {
-        BenchmarkUtils.deleteRecursive(tempDir.toPath());
+    @TearDown(Level.Trial) public void clearTemp() throws IOException {
+        scala.bench.IOUtils.deleteRecursive(tempDir.toPath());
     }
-
 }


### PR DESCRIPTION
If a recent JDK is used to run SBT, the JMH source generator
task fails when generating the benchmark sources based on
JavacBenchmark with this failure:

```
Annotation generator had thrown the exception.
java.lang.NoClassDefFoundError: javax/tools/JavaCompiler
	at java.base/java.lang.Class.getDeclaredFields0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredFields(Class.java:3229)
	at java.base/java.lang.Class.getDeclaredFields(Class.java:2335)
	at org.openjdk.jmh.generators.reflection.RFClassInfo.getFields(RFClassInfo.java:81)
	at org.openjdk.jmh.generators.core.BenchmarkGeneratorUtils.getAllFields(BenchmarkGeneratorUtils.java:128)
	at org.openjdk.jmh.generators.core.StateObjectHandler.validateState(StateObjectHandler.java:126)
	at org.openjdk.jmh.generators.core.BenchmarkGenerator.validateBenchmark(BenchmarkGenerator.java:246)
	at org.openjdk.jmh.generators.core.BenchmarkGenerator.generate(BenchmarkGenerator.java:83)
	at org.openjdk.jmh.generators.bytecode.JmhBytecodeGenerator.main(JmhBytecodeGenerator.java:100)
  | => jat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at sbt.Run.invokeMain(Run.scala:115)
	at sbt.Run.execute$1(Run.scala:79)
	at sbt.Run.$anonfun$runWithLoader$4(Run.scala:92)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at sbt.util.InterfaceUtil$$anon$1.get(InterfaceUtil.scala:10)
	at sbt.TrapExit$App.run(TrapExit.scala:257)
	at java.base/java.lang.Thread.run(Thread.java:831)
Caused by: java.lang.ClassNotFoundException: javax.tools.JavaCompiler
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:433)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:586)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)
	... 20 more
```

The workaround is to use an older JDK to build the project and only
use the new JDK as the `-jvm` parameter to the `jmh:run` task.

However, for casual use it is convenient to just switch the JDK in the
shell before starting SBT, so this commit makes that possible for the
common case of running ScalacBenchmark.