### PR TITLE
Deduplicate historical Java version tag and upgrade client library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val infrastructure = addJmh(project).settings(
   autoScalaLibrary := false,
   crossPaths := false,
   libraryDependencies ++= Seq(
-    "org.influxdb" % "influxdb-java" % "2.5", // TODO update to 2.6 when released for fix for https://github.com/influxdata/influxdb-java/issues/269
+    "org.influxdb" % "influxdb-java" % "2.21",
     "org.eclipse.jgit" % "org.eclipse.jgit" % "4.6.0.201612231935-r",
     "com.google.guava" % "guava" % "21.0",
     "org.apache.commons" % "commons-lang3" % "3.5",

--- a/infrastructure/src/main/java/scala/bench/Database.java
+++ b/infrastructure/src/main/java/scala/bench/Database.java
@@ -30,20 +30,7 @@ public class Database {
         client.connectTimeout(10, TimeUnit.SECONDS);
         client.readTimeout(120, TimeUnit.SECONDS);
         client.writeTimeout(120, TimeUnit.SECONDS);
-
-        // workaround https://github.com/influxdata/influxdb-java/issues/268
-        client.addNetworkInterceptor(chain -> {
-            HttpUrl.Builder fixedUrl = chain.request().url().newBuilder().encodedPath("/influx/" + chain.request().url().encodedPath().replaceFirst("/influxdb", ""));
-            return chain.proceed(chain.request().newBuilder().url(fixedUrl.build()).build());
-        });
-
-        client.authenticator((route, response) -> {
-            String credential = Credentials.basic(influxUser, influxPassword);
-            return response.request().newBuilder()
-                    .header("Authorization", credential)
-                    .build();
-        });
-        InfluxDB influxDB = InfluxDBFactory.connect(influxUrl, influxUser, influxPassword, client);
+        InfluxDB influxDB = InfluxDBFactory.connect(influxUrl, influxUser, influxPassword, client, InfluxDB.ResponseFormat.MSGPACK);
         // influxDB.setLogLevel(InfluxDB.LogLevel.FULL);
         return influxDB;
     }


### PR DESCRIPTION
The new way of extracting the Java version doesn't include the internal
build number, so remove that from historical data.

First, upgrade the InfluxDB client library.

This fixes two issues that I reported long ago with Nginx reverse proxy
and basic authentication, so remove the workarounds.

It also has a new feature to talk to the server in a binary protocal
(Message Pack). Apart from being more efficient (which doesn't really
matter much to us) it also doesn't lose track of int vs float
data types when doing a bulk query (like we do in the migrator)
which avoids needing to manually narrow "sampleCount" to a integral
type.